### PR TITLE
Add option to discard tabs on opening

### DIFF
--- a/options.html
+++ b/options.html
@@ -7,7 +7,9 @@
 <form>
   <label><input type="checkbox" name="showTabContextMenuCopyUrls" id="showTabContextMenuCopyUrls"> Show "Copy URLs" entry in tab context menu</label>
   <br>
-  <label><input type="checkbox" name="openUrlsAlreadyOpened" id="openUrlsAlreadyOpened"> Open URLs which are already opened in other Tabs</label>
+  <label><input type="checkbox" name="openUrlsAlreadyOpened" id="openUrlsAlreadyOpened"> Open URLs which are already opened in other tabs</label>
+  <br>
+  <label><input type="checkbox" name="openTabsAsDiscarded" id="openTabsAsDiscarded"> Open tabs in an unloaded (discarded) state</label>
   <br>
   <button type="submit">Save</button>
 </form>

--- a/options.js
+++ b/options.js
@@ -3,6 +3,7 @@ function saveOptions(e) {
   browser.storage.sync.set({
     showTabContextMenuCopyUrls: document.querySelector("#showTabContextMenuCopyUrls").checked,
     openUrlsAlreadyOpened: document.querySelector("#openUrlsAlreadyOpened").checked,
+    openTabsAsDiscarded: document.querySelector("#openTabsAsDiscarded").checked,
   });
   browser.runtime.sendMessage({});
 }
@@ -11,8 +12,10 @@ function restoreOptions() {
   browser.storage.sync.get().then(settings => {
     let showContextMenu = ('showTabContextMenuCopyUrls' in settings) ? settings.showTabContextMenuCopyUrls : true;
     let openTabs = ('openUrlsAlreadyOpened' in settings) ? settings.openUrlsAlreadyOpened : false;
+    let discardTabs = ('openTabsAsDiscarded' in settings) ? settings.openTabsAsDiscarded : false;
     document.querySelector("#showTabContextMenuCopyUrls").checked = showContextMenu;
     document.querySelector("#openUrlsAlreadyOpened").checked = openTabs;
+    document.querySelector("#openTabsAsDiscarded").checked = discardTabs;
   }, error => {
     console.log(`Error: ${error}`);
   });

--- a/popup/urls-list.js
+++ b/popup/urls-list.js
@@ -10,8 +10,10 @@ let filterInput = document.querySelector('.filterInput');
 let filterWarning = document.querySelector('.filterWarning');
 
 let alwaysOpenAllTabs = false;
+let discardTabs = false;
 browser.storage.sync.get().then(settings => {
   alwaysOpenAllTabs = ('openUrlsAlreadyOpened' in settings) ? settings.openUrlsAlreadyOpened : false;
+  discardTabs = ('openTabsAsDiscarded' in settings) ? settings.openTabsAsDiscarded : false;
 }, error => {
   console.log(`Error: ${error}`);
 });
@@ -45,6 +47,7 @@ function open() {
         }
         browser.tabs.create({
           active: false,
+          discarded: discardTabs,
           url: url
         });
       }


### PR DESCRIPTION
Adds a new option to open tabs by default in a discarded state. This is set to `false` by default which mimics the current behavior.

This dramatically reduces resource consumption when loading tabs and helps mitigate the risk of creating a large number of requests to a host resulting in being punished (e.g. by rate limited or denied access) for that event.

Closes #33.